### PR TITLE
Use permissions if running as root

### DIFF
--- a/dm.pl
+++ b/dm.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use English;
 use File::Find;
 use File::Spec;
 use Cwd;
@@ -171,9 +172,15 @@ sub tar_filelist {
 	find({wanted => sub {
 		return if m#^./DEBIAN#;
 		my $tf = NIC::Archive::Tar::File->new(file=>$_);
-		my $mode = (lstat($_))[2] & 07777;
+		my @stat = lstat($_);
+		my $mode = $stat[2] & 07777;
 		$tf->mode($mode);
-		$tf->chown("root", "wheel");
+		if ($< == 0) {
+			# Runing under fake or real root
+			$tf->chown($stat[4], $stat[5]);
+		} else {
+			$tf->chown("root", "wheel");
+		}
 		push @symlinks, $tf if -l;
 		push @filelist, $tf if ! -l;
 	}, no_chdir => 1}, ".");


### PR DESCRIPTION
This allows dm.pl to package specific UIDs and GIDs if the process reports it is running as root while preserving the minimal fake ownership when not run under fakeroot.  It uses user ID numbers instead of names because the name on the build system will generally not match that of the destination device.