### PR TITLE
Drop support for commas in the pkg name

### DIFF
--- a/dm.pl
+++ b/dm.pl
@@ -78,7 +78,7 @@ die "ERROR: control file '$controlfile' is missing a Package field" unless defin
 die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
 
-die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if($control_data{"package"} =~ m/[^a-z0-9+-.]/);
+die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if($control_data{"package"} =~ m/[^a-z0-9+.-]/);
 die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits.\n" if($control_data{"version"} !~ m/[0-9]/);
 
 foreach my $m ("preinst", "postinst", "prerm", "postrm", "extrainst_") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Adjusts the regex for supported characters in the package name.

Does this close any currently open issues?
------------------------------------------
Not that I'm aware of, no.

Any relevant logs, error output, etc?
-------------------------------------
For a project named `this is!,./a 2!@#$%^&*( test\` (with all invalid characters *EXCEPT* the comma removed)
dm.pl's output:
``` 
> Making all for tool thisis,.a2test…
==> Compiling main.m (arm64)…
==> Compiling main.m (armv7)…
==> Compiling main.m (arm64e)…
==> Linking tool thisis,.a2test (arm64)…
==> Generating debug symbols for thisis,.a2test…
==> Linking tool thisis,.a2test (armv7)…
==> Generating debug symbols for thisis,.a2test…
==> Linking tool thisis,.a2test (arm64e)…
==> Generating debug symbols for thisis,.a2test…
==> Merging tool thisis,.a2test…
==> Signing thisis,.a2test…
> Making stage for tool thisis,.a2test…
ERROR: package name has characters that aren't lowercase alphanums or '-+.'.
make: *** [/home/lightmann/Documents/my-theos/makefiles/package/deb.mk:59: internal-package] Error 255
```

Any other comments?
-------------------
This pr goes hand in hand with [nic#16](https://github.com/theos/nic/pull/16) which now also properly strips invalid characters (including the comma -- thanks to Kirb).

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
