### PR TITLE
Add two new checks + standardize formatting for a couple things

### DIFF
--- a/dm.pl
+++ b/dm.pl
@@ -23,7 +23,7 @@ sub new {
 sub full_path {
 	my $self = shift;
 	my $full_path = $self->SUPER::full_path(); $full_path = '' unless defined $full_path;
-	$full_path =~ s#^#./# if $full_path ne "" && $full_path ne "." && $full_path !~ m#^\./#;
+	$full_path =~ s#^#./# if ($full_path ne "" && $full_path ne "." && $full_path !~ m#^\./#);
 	return $full_path;
 }
 1;
@@ -47,14 +47,14 @@ GetOptions('compression|Z=s' => \$compression,
 	'man' => sub { pod2usage(-exitstatus => 0, -verbose => 2); })
 	or pod2usage(2);
 
-pod2usage(1) if(@ARGV < 2);
+pod2usage(1) if (@ARGV < 2);
 
-if($compresslevel < 0 || $compresslevel > 9) {
+if ($compresslevel < 0 || $compresslevel > 9) {
 	$compresslevel = 6;
-	$compresslevel = 9 if $compression eq "bzip2";
+	$compresslevel = 9 if ($compression eq "bzip2");
 }
 
-if($compresslevel eq 0) {
+if ($compresslevel eq 0) {
 	$compresslevel = 1;
 }
 
@@ -68,7 +68,7 @@ my $controldir = File::Spec->catpath("", $indir, "DEBIAN");
 
 die "ERROR: control directory '$controldir' is not a directory or does not exist.\n" unless -d $controldir;
 my $mode = (lstat($controldir))[2];
-die sprintf("ERROR: control directory has bad permissions %03lo (must be >=0755 and <=0775)\n", $mode & 07777) if(($mode & 07757) != 0755);
+die sprintf("ERROR: control directory has bad permissions %03lo (must be >=0755 and <=0775)\n", $mode & 07777) if (($mode & 07757) != 0755);
 
 my $controlfile = File::Spec->catfile($controldir, "control");
 die "ERROR: control file '$controlfile' is not a plain file\n" unless -f $controlfile;
@@ -77,17 +77,17 @@ my %control_data = read_control_file($controlfile);
 die "ERROR: control file '$controlfile' is missing a Package field" unless defined $control_data{"package"};
 die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
-die "ERROR: control file '$controlfile' is missing a final newline (\\n).\n" if($control_data{"eof"} ne "\n");
+die "ERROR: control file '$controlfile' is missing a final newline (\\n).\n" if ($control_data{"eof"} ne "\n");
 
-die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if($control_data{"package"} =~ m/[^a-z0-9+-.]/);
-die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits.\n" if($control_data{"version"} !~ m/[0-9]/);
+die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if ($control_data{"package"} =~ m/[^a-z0-9+-.]/);
+die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits.\n" if ($control_data{"version"} !~ m/[0-9]/);
 
 foreach my $m ("preinst", "postinst", "prerm", "postrm", "extrainst_") {
 	$_ = File::Spec->catfile($controldir, $m);
 	next unless -e $_;
 	die "ERROR: maintainer script '$m' is not a plain file or symlink\n" unless(-f $_ || -l $_);
 	$mode = (lstat)[2];
-	die sprintf("ERROR: maintainer script '$m' has bad permissions %03lo (must be >=0555 and <=0775)\n", $mode & 07777) if(($mode & 07557) != 0555)
+	die sprintf("ERROR: maintainer script '$m' has bad permissions %03lo (must be >=0555 and <=0775)\n", $mode & 07777) if (($mode & 07557) != 0555);
 }
 
 if (-d "$outfile") {
@@ -170,7 +170,7 @@ sub print_ar_record {
 sub print_ar_file {
 	my ($fh, $data, $size) = @_;
 	syswrite $fh, $data;
-	print $fh "\n" if($size % 2 == 1);
+	print $fh "\n" if ($size % 2 == 1);
 	$fh->flush();
 }
 
@@ -180,7 +180,7 @@ sub tar_filelist {
 	my @filelist;
 
 	find({wanted => sub {
-		return if m#^./DEBIAN#;
+		return if (m#^./DEBIAN#);
 		my $tf = NIC::Archive::Tar::File->new(file=>$_);
 		my @stat = lstat($_);
 		my $mode = $stat[2] & 07777;
@@ -202,8 +202,8 @@ sub read_control_file {
 	open(my $fh, '<', $filename) or die "ERROR: can't open control file '$filename'\n";
 	my %data;
 	while(<$fh>) {
-		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if(m/\r/);
-		if(m/^(.*?): (.*)/) {
+		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if (m/\r/);
+		if (m/^(.*?): (.*)/) {
 			$data{lc($1)} = $2;
 		}
 		if (eof) {
@@ -215,11 +215,11 @@ sub read_control_file {
 }
 
 sub compression_cmd {
-	return "gzip -c".$compresslevel if $::compression eq "gzip";
-	return "bzip2 -c".$compresslevel if $::compression eq "bzip2";
-	return "lzma -c".$compresslevel if $::compression eq "lzma";
-	return "xz -c".$compresslevel if $::compression eq "xz";
-	if($::compression ne "cat") {
+	return "gzip -c".$compresslevel if ($::compression eq "gzip");
+	return "bzip2 -c".$compresslevel if ($::compression eq "bzip2");
+	return "lzma -c".$compresslevel if ($::compression eq "lzma");
+	return "xz -c".$compresslevel if ($::compression eq "xz");
+	if ($::compression ne "cat") {
 		print "WARNING: compressor '$::compression' is unknown, falling back to cat.\n";
 	}
 	return "cat";
@@ -228,10 +228,10 @@ sub compression_cmd {
 sub compressed_filename {
 	my $fn = shift;
 	my $suffix = "";
-	$suffix = ".gz" if $::compression eq "gzip";
-	$suffix = ".bz2" if $::compression eq "bzip2";
-	$suffix = ".lzma" if $::compression eq "lzma";
-	$suffix = ".xz" if $::compression eq "xz";
+	$suffix = ".gz" if ($::compression eq "gzip");
+	$suffix = ".bz2" if ($::compression eq "bzip2");
+	$suffix = ".lzma" if ($::compression eq "lzma");
+	$suffix = ".xz" if ($::compression eq "xz");
 	return $fn.$suffix;
 }
 

--- a/dm.pl
+++ b/dm.pl
@@ -62,11 +62,11 @@ my $pwd = Cwd::cwd();
 my $indir = File::Spec->rel2abs($ARGV[0]);
 my $outfile = $ARGV[1];
 
-die "ERROR: '$indir' is not a directory or does not exist.\n" unless -d $indir;
+die "ERROR: '$indir' is not a directory or does not exist\n" unless -d $indir;
 
 my $controldir = File::Spec->catpath("", $indir, "DEBIAN");
 
-die "ERROR: control directory '$controldir' is not a directory or does not exist.\n" unless -d $controldir;
+die "ERROR: control directory '$controldir' is not a directory or does not exist\n" unless -d $controldir;
 my $mode = (lstat($controldir))[2];
 die sprintf("ERROR: control directory has bad permissions %03lo (must be >=0755 and <=0775)\n", $mode & 07777) if (($mode & 07757) != 0755);
 
@@ -78,8 +78,8 @@ die "ERROR: control file '$controlfile' is missing a Package field" unless defin
 die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
 
-die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if ($control_data{"package"} =~ m/[^a-z0-9+-.]/);
-die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits.\n" if ($control_data{"version"} !~ m/[0-9]/);
+die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'\n" if ($control_data{"package"} =~ m/[^a-z0-9+-.]/);
+die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits\n" if ($control_data{"version"} !~ m/[0-9]/);
 
 foreach my $m ("preinst", "postinst", "prerm", "postrm", "extrainst_") {
 	$_ = File::Spec->catfile($controldir, $m);

--- a/dm.pl
+++ b/dm.pl
@@ -204,7 +204,7 @@ sub read_control_file {
 		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if (m/\r/);
 		if (m/^(.*?): (.*)/) {
 			$data{lc($1)} = $2;
-			die "ERROR: control file contains an unclosed parentheses\n" if ($_ =~ /\(/ && $_ !~ /\)/);
+			die "ERROR: control file contains an unclosed parentheses\n" if (($_ =~ /\(/ && $_ !~ /\)/) || ($_ !~ /\(/ && $_ =~ /\)/));
 		}
 		if (eof) {
 			die "ERROR: control file is missing a final newline (\\n)\n" if (substr($_, -1) ne "\n");

--- a/dm.pl
+++ b/dm.pl
@@ -78,7 +78,7 @@ die "ERROR: control file '$controlfile' is missing a Package field" unless defin
 die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
 
-die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'\n" if ($control_data{"package"} =~ m/[^a-z0-9+-.]/);
+die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'\n" if ($control_data{"package"} =~ m/[^a-z0-9+.-]/);
 die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits\n" if ($control_data{"version"} !~ m/[0-9]/);
 
 foreach my $m ("preinst", "postinst", "prerm", "postrm", "extrainst_") {

--- a/dm.pl
+++ b/dm.pl
@@ -204,7 +204,7 @@ sub read_control_file {
 		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if (m/\r/);
 		if (m/^(.*?): (.*)/) {
 			$data{lc($1)} = $2;
-			die "ERROR: control file contains an unclosed parenthesis\n" if ($_ =~ /\(/ && $_ !~ /\)/);
+			die "ERROR: control file contains an unclosed parentheses\n" if ($_ =~ /\(/ && $_ !~ /\)/);
 		}
 		if (eof) {
 			die "ERROR: control file is missing a final newline (\\n)\n" if (substr($_, -1) ne "\n");

--- a/dm.pl
+++ b/dm.pl
@@ -13,20 +13,23 @@ use POSIX;
 
 package NIC::Archive::Tar::File;
 use parent "Archive::Tar::File";
+
 sub new {
 	my $class = shift;
-	my $self = Archive::Tar::File->new(@_);
+	my $self  = Archive::Tar::File->new(@_);
 	bless($self, $class);
 	return $self;
 }
 
 sub full_path {
-	my $self = shift;
-	my $full_path = $self->SUPER::full_path(); $full_path = '' unless defined $full_path;
+	my $self      = shift;
+	my $full_path = $self->SUPER::full_path();
+	$full_path = '' unless defined $full_path;
 	$full_path =~ s#^#./# if ($full_path ne "" && $full_path ne "." && $full_path !~ m#^\./#);
 	return $full_path;
 }
 1;
+
 package main;
 
 our $VERSION = '2.0';
@@ -34,18 +37,19 @@ our $VERSION = '2.0';
 our $_PROGNAME = "dm.pl";
 
 my $ADMINARCHIVENAME = "control.tar.gz";
-my $DATAARCHIVENAME = "data.tar";
-my $ARCHIVEVERSION = "2.0";
+my $DATAARCHIVENAME  = "data.tar";
+my $ARCHIVEVERSION   = "2.0";
 
-our $compression = "gzip";
+our $compression   = "gzip";
 our $compresslevel = -1;
 Getopt::Long::Configure("bundling", "auto_version");
-GetOptions('compression|Z=s' => \$compression,
+GetOptions(
+	'compression|Z=s'    => \$compression,
 	'compress-level|z=i' => \$compresslevel,
-	'build|b' => sub { },
-	'help|?' => sub { pod2usage(1); },
-	'man' => sub { pod2usage(-exitstatus => 0, -verbose => 2); })
-	or pod2usage(2);
+	'build|b'            => sub { },
+	'help|?'             => sub { pod2usage(1); },
+	'man'                => sub { pod2usage(-exitstatus => 0, -verbose => 2); }
+) or pod2usage(2);
 
 pod2usage(1) if (@ARGV < 2);
 
@@ -58,8 +62,8 @@ if ($compresslevel eq 0) {
 	$compresslevel = 1;
 }
 
-my $pwd = Cwd::cwd();
-my $indir = File::Spec->rel2abs($ARGV[0]);
+my $pwd     = Cwd::cwd();
+my $indir   = File::Spec->rel2abs($ARGV[0]);
 my $outfile = $ARGV[1];
 
 die "ERROR: '$indir' is not a directory or does not exist\n" unless -d $indir;
@@ -68,32 +72,43 @@ my $controldir = File::Spec->catpath("", $indir, "DEBIAN");
 
 die "ERROR: control directory '$controldir' is not a directory or does not exist\n" unless -d $controldir;
 my $mode = (lstat($controldir))[2];
-die sprintf("ERROR: control directory has bad permissions %03lo (must be >=0755 and <=0775)\n", $mode & 07777) if (($mode & 07757) != 0755);
+die sprintf("ERROR: control directory has bad permissions %03lo (must be >=0755 and <=0775)\n", $mode & 07777)
+  if (($mode & 07757) != 0755);
 
 my $controlfile = File::Spec->catfile($controldir, "control");
 die "ERROR: control file '$controlfile' is not a plain file\n" unless -f $controlfile;
 my %control_data = read_control_file($controlfile);
 
-die "ERROR: control file '$controlfile' is missing a Package field" unless defined $control_data{"package"};
-die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
+die "ERROR: control file '$controlfile' is missing a Package field"       unless defined $control_data{"package"};
+die "ERROR: control file '$controlfile' is missing a Version field"       unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
 
-die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'\n" if ($control_data{"package"} =~ m/[^a-z0-9+.-]/);
-die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits\n" if ($control_data{"version"} !~ m/[0-9]/);
+die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'\n"
+  if ($control_data{"package"} =~ m/[^a-z0-9+.-]/);
+die "ERROR: package version " . $control_data{"version"} . " doesn't contain any digits\n"
+  if ($control_data{"version"} !~ m/[0-9]/);
 
 foreach my $m ("preinst", "postinst", "prerm", "postrm", "extrainst_") {
 	$_ = File::Spec->catfile($controldir, $m);
-	next unless -e $_;
-	die "ERROR: maintainer script '$m' is not a plain file or symlink\n" unless(-f $_ || -l $_);
+	next                                                                 unless -e $_;
+	die "ERROR: maintainer script '$m' is not a plain file or symlink\n" unless (-f $_ || -l $_);
 	$mode = (lstat)[2];
-	die sprintf("ERROR: maintainer script '$m' has bad permissions %03lo (must be >=0555 and <=0775)\n", $mode & 07777) if (($mode & 07557) != 0555);
+	die sprintf("ERROR: maintainer script '$m' has bad permissions %03lo (must be >=0555 and <=0775)\n", $mode & 07777)
+	  if (($mode & 07557) != 0555);
 }
 
 if (-d "$outfile") {
-	$outfile = sprintf('%s/%s_%s_%s.deb', $outfile, $control_data{"package"}, $control_data{"version"}, $control_data{"architecture"});
+	$outfile = sprintf('%s/%s_%s_%s.deb',
+		$outfile,
+		$control_data{"package"},
+		$control_data{"version"},
+		$control_data{"architecture"});
 }
 
-print "$_PROGNAME: building package `".$control_data{"package"}.":".$control_data{"architecture"}."' in `$outfile'\n";
+print "$_PROGNAME: building package `"
+  . $control_data{"package"} . ":"
+  . $control_data{"architecture"}
+  . "' in `$outfile'\n";
 
 open(my $ar, '>', $outfile) or die $!;
 
@@ -110,31 +125,36 @@ print_ar_file($ar, "$ARCHIVEVERSION\n", 4);
 	$zFd->close();
 	print_ar_record($ar, $ADMINARCHIVENAME, time, 0, 0, 0100644, length($comp));
 	print_ar_file($ar, $comp, length($comp));
-} {
+}
+{
 	my $tar = Archive::Tar->new();
 	$tar->add_files(tar_filelist($indir));
 	my ($fh_out, $fh_in);
-	my $pid = open2($fh_out, $fh_in, compression_cmd()) or die "ERROR: open2 failed to create pipes for '$::compression'\n";
+	my $pid = open2($fh_out, $fh_in, compression_cmd())
+	  or die "ERROR: open2 failed to create pipes for '$::compression'\n";
 	fcntl($fh_out, F_SETFL, O_NONBLOCK);
-	fcntl($fh_in, F_SETFL, O_NONBLOCK);
+	fcntl($fh_in,  F_SETFL, O_NONBLOCK);
 	my $tmp_data = $tar->write();
 	my $tmp_size = length($tmp_data);
 
-	my ($off_in, $off_out) = (0, 0);
+	my ($off_in,      $off_out) = (0, 0);
 	my ($archivedata, $archivesize);
-	while($off_in < $tmp_size) {
-		my ($rin, $win) = ('', '');
+	while ($off_in < $tmp_size) {
+		my ($rin,  $win) = ('', '');
 		my ($rout, $wout);
-		vec($win, fileno($fh_in), 1) = 1;
+		vec($win, fileno($fh_in),  1) = 1;
 		vec($rin, fileno($fh_out), 1) = 1;
+
 		# Wait for space to be available to write or data to be available to read
-		select($rout=$rin, $wout=$win, undef, undef);
+		select($rout = $rin, $wout = $win, undef, undef);
 		if (vec($wout, fileno($fh_in), 1)) {
+
 			# Write 8KB of data
 			my $wrote = syswrite $fh_in, $tmp_data, 8192, $off_in;
 			$off_in += $wrote if (defined $wrote);
 		}
 		if (vec($rin, fileno($fh_out), 1)) {
+
 			# Get the compressed result if possible
 			my $o = sysread $fh_out, $archivedata, 8192, $off_out;
 			$off_out += $o if (defined($o));
@@ -143,11 +163,13 @@ print_ar_file($ar, "$ARCHIVEVERSION\n", 4);
 	$fh_in->close();
 
 	while (1) {
+
 		# Get the remaining data
 		my $o = sysread $fh_out, $archivedata, 8192, $off_out;
 		if (defined($o) && $o > 0) {
 			$off_out += $o;
-		} elsif ($! != EAGAIN) {
+		}
+		elsif ($! != EAGAIN) {
 			last;
 		}
 	}
@@ -178,20 +200,28 @@ sub tar_filelist {
 	chdir(shift);
 	my @filelist;
 
-	find({wanted => sub {
-		return if (m#^./DEBIAN#);
-		my $tf = NIC::Archive::Tar::File->new(file=>$_);
-		my @stat = lstat($_);
-		my $mode = $stat[2] & 07777;
-		$tf->mode($mode);
-		if ($< == 0) {
-			# Runing under fake or real root
-			$tf->chown($stat[4], $stat[5]);
-		} else {
-			$tf->chown("root", "wheel");
-		}
-		push @filelist, $tf;
-	}, no_chdir => 1}, ".");
+	find(
+		{
+			wanted => sub {
+				return if (m#^./DEBIAN#);
+				my $tf   = NIC::Archive::Tar::File->new(file => $_);
+				my @stat = lstat($_);
+				my $mode = $stat[2] & 07777;
+				$tf->mode($mode);
+				if ($< == 0) {
+
+					# Runing under fake or real root
+					$tf->chown($stat[4], $stat[5]);
+				}
+				else {
+					$tf->chown("root", "wheel");
+				}
+				push @filelist, $tf;
+			},
+			no_chdir => 1
+		},
+		"."
+	);
 	chdir($dir);
 	return sort { $a->full_path cmp $b->full_path } @filelist;
 }
@@ -200,11 +230,14 @@ sub read_control_file {
 	my $filename = shift;
 	open(my $fh, '<', $filename) or die "ERROR: can't open control file '$filename'\n";
 	my %data;
-	while(<$fh>) {
-		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if (m/\r/);
+	while (<$fh>) {
+		die
+		  "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n"
+		  if (m/\r/);
 		if (m/^(.*?): (.*)/) {
 			$data{lc($1)} = $2;
-			die "ERROR: control file contains an unclosed parentheses\n" if (($_ =~ /\(/ && $_ !~ /\)/) || ($_ !~ /\(/ && $_ =~ /\)/));
+			die "ERROR: control file contains an unclosed parentheses\n"
+			  if (($_ =~ /\(/ && $_ !~ /\)/) || ($_ !~ /\(/ && $_ =~ /\)/));
 		}
 		if (eof) {
 			die "ERROR: control file is missing a final newline (\\n)\n" if (substr($_, -1) ne "\n");
@@ -215,10 +248,10 @@ sub read_control_file {
 }
 
 sub compression_cmd {
-	return "gzip -c".$compresslevel if ($::compression eq "gzip");
-	return "bzip2 -c".$compresslevel if ($::compression eq "bzip2");
-	return "lzma -c".$compresslevel if ($::compression eq "lzma");
-	return "xz -c".$compresslevel if ($::compression eq "xz");
+	return "gzip -c" . $compresslevel  if ($::compression eq "gzip");
+	return "bzip2 -c" . $compresslevel if ($::compression eq "bzip2");
+	return "lzma -c" . $compresslevel  if ($::compression eq "lzma");
+	return "xz -c" . $compresslevel    if ($::compression eq "xz");
 	if ($::compression ne "cat") {
 		print "WARNING: compressor '$::compression' is unknown, falling back to cat.\n";
 	}
@@ -226,13 +259,13 @@ sub compression_cmd {
 }
 
 sub compressed_filename {
-	my $fn = shift;
+	my $fn     = shift;
 	my $suffix = "";
-	$suffix = ".gz" if ($::compression eq "gzip");
-	$suffix = ".bz2" if ($::compression eq "bzip2");
+	$suffix = ".gz"   if ($::compression eq "gzip");
+	$suffix = ".bz2"  if ($::compression eq "bzip2");
 	$suffix = ".lzma" if ($::compression eq "lzma");
-	$suffix = ".xz" if ($::compression eq "xz");
-	return $fn.$suffix;
+	$suffix = ".xz"   if ($::compression eq "xz");
+	return $fn . $suffix;
 }
 
 __END__

--- a/dm.pl
+++ b/dm.pl
@@ -77,7 +77,6 @@ my %control_data = read_control_file($controlfile);
 die "ERROR: control file '$controlfile' is missing a Package field" unless defined $control_data{"package"};
 die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
-die "ERROR: control file '$controlfile' is missing a final newline (\\n).\n" if ($control_data{"eof"} ne "\n");
 
 die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if ($control_data{"package"} =~ m/[^a-z0-9+-.]/);
 die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits.\n" if ($control_data{"version"} !~ m/[0-9]/);
@@ -205,9 +204,10 @@ sub read_control_file {
 		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if (m/\r/);
 		if (m/^(.*?): (.*)/) {
 			$data{lc($1)} = $2;
+			die "ERROR: control file contains an unclosed parenthesis\n" if ($_ =~ /\(/ && $_ !~ /\)/);
 		}
 		if (eof) {
-			$data{"eof"} = substr($_, -1);
+			die "ERROR: control file is missing a final newline (\\n)\n" if (substr($_, -1) ne "\n");
 		}
 	}
 	close $fh;

--- a/dm.pl
+++ b/dm.pl
@@ -77,6 +77,7 @@ my %control_data = read_control_file($controlfile);
 die "ERROR: control file '$controlfile' is missing a Package field" unless defined $control_data{"package"};
 die "ERROR: control file '$controlfile' is missing a Version field" unless defined $control_data{"version"};
 die "ERROR: control file '$controlfile' is missing an Architecture field" unless defined $control_data{"architecture"};
+die "ERROR: control file '$controlfile' is missing a final newline (\\n).\n" if($control_data{"eof"} ne "\n");
 
 die "ERROR: package name has characters that aren't lowercase alphanums or '-+.'.\n" if($control_data{"package"} =~ m/[^a-z0-9+-.]/);
 die "ERROR: package version ".$control_data{"version"}." doesn't contain any digits.\n" if($control_data{"version"} !~ m/[0-9]/);
@@ -204,6 +205,9 @@ sub read_control_file {
 		die "ERROR: control file contains Windows/Macintosh line endings - please use a text editor or dos2unix to change to Unix line endings\n" if(m/\r/);
 		if(m/^(.*?): (.*)/) {
 			$data{lc($1)} = $2;
+		}
+		if (eof) {
+			$data{"eof"} = substr($_, -1);
 		}
 	}
 	close $fh;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link below to view the contribution guidelines, then fill out the blanks below. -->

What does this implement/fix? Explain your changes.
---------------------------------------------------
1) Adds check for final newline
2) Adds check for unclosed parentheses 
3) Standardizes 'if' formatting (adds space after "if" and parentheses around the condition(s))
4) Standardizes error message formatting (removes periods from end of string)

Does this close any currently open issues?
------------------------------------------
Nope

Any relevant logs, error output, etc?
-------------------------------------
```
> Making stage for tweak test…
ERROR: control file is missing a final newline (\n)
make: *** [/home/lightmann/theos/makefiles/package/deb.mk:59: internal-package] Error 25
```
```
> Making stage for tweak test…
ERROR: control file contains an unclosed parentheses
make: *** [/home/lightmann/theos/makefiles/package/deb.mk:59: internal-package] Error 25
```

Any other comments?
-------------------
Nope

Where has this been tested?
---------------------------
**Operating System:** …

Linux (WSL)

**Platform:** …

**Target Platform:** …

**Toolchain Version:** …

**SDK Version:** …
